### PR TITLE
fix: Corregir generación de URLs de alquiler para ubicaciones con múltiples segmentos

### DIFF
--- a/app/scripts/domain/services/url-analyzer.ts
+++ b/app/scripts/domain/services/url-analyzer.ts
@@ -54,7 +54,11 @@ export class UrlAnalyzer implements IUrlAnalyzer {
   }
 
   private extractLocationFromUrl(pathname: string): string | null {
-    const match = pathname.match(/\/(venta|alquiler)-viviendas\/([^/]+)/);
-    return match ? match[2] : null;
+    const match = pathname.match(/\/(venta|alquiler)-viviendas\/(.+?)(?:\/pagina-\d+\.htm|\?|$)/);
+    if (match) {
+      // Remove trailing slash if present
+      return match[2].replace(/\/$/, '');
+    }
+    return null;
   }
 }


### PR DESCRIPTION
## Summary

- Corrige el problema de generación de URLs de alquiler para ubicaciones con múltiples segmentos de ruta
- Soluciona errores 404 al buscar propiedades de alquiler en ubicaciones específicas como `/malaga/bailen-miraflores/`

## Problema
El regex anterior `/(venta|alquiler)-viviendas\/([^/]+)/` solo capturaba el primer segmento después del tipo de propiedad:
- URL: `https://www.idealista.com/venta-viviendas/malaga/bailen-miraflores/`  
- Ubicación extraída: `malaga` (incorrecto)
- URL de alquiler generada: `https://www.idealista.com/alquiler-viviendas/malaga/` → 404

## Solución
Nuevo regex `/(venta|alquiler)-viviendas\/(.+?)(?:\/pagina-\d+\.htm|\?|$)/` que:
- Captura toda la ruta de ubicación: `malaga/bailen-miraflores`
- Excluye correctamente paginación (`/pagina-X.htm`) y parámetros de consulta
- Elimina barras finales innecesarias

## Test plan
- [x] Verificar extracción correcta para URLs con múltiples segmentos
- [x] Verificar que URLs con paginación siguen funcionando
- [x] Confirmar que URLs simples (un solo segmento) no se ven afectadas
- [x] Probar casos edge: barras finales, parámetros de consulta

🤖 Generated with [Claude Code](https://claude.ai/code)